### PR TITLE
プロトタイプ一覧表示機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,5 @@
 class PrototypesController < ApplicationController
   def index
+    @prototypes = Prototype.all
   end
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,0 +1,2 @@
+class Prototype < ApplicationRecord
+end

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -1,6 +1,5 @@
 <main class="main">
   <div class="inner">
-    <%# ログインしているときは以下を表示する %>
       <% if user_signed_in? %>
       <div class="greeting"> 
         こんにちは、
@@ -11,6 +10,9 @@
           <%# // ログインしているときは上記を表示する %>
     <div class="card__wrapper">
       <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
+      <% @prototypes.each do |prototype| %>
+        <%= render partial: "prototype" %>
+      <% end %>
     </div>
   </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root "prototypes#index"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  resources :prototypes
 end

--- a/db/migrate/20240919015426_create_prototypes.rb
+++ b/db/migrate/20240919015426_create_prototypes.rb
@@ -1,0 +1,8 @@
+class CreatePrototypes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :prototypes do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240919015426_create_prototypes.rb
+++ b/db/migrate/20240919015426_create_prototypes.rb
@@ -1,6 +1,10 @@
 class CreatePrototypes < ActiveRecord::Migration[7.0]
   def change
     create_table :prototypes do |t|
+      t.string :title, null:false
+      t.text :catch_copy, null:false
+      t.text :concept, null:false
+      t.references :user, foreign_key: true, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_18_070525) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_19_015426) do
+  create_table "prototypes", charset: "utf8mb3", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "catch_copy", null: false
+    t.text "concept", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_prototypes_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb3", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -27,4 +37,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_18_070525) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "prototypes", "users"
 end

--- a/test/fixtures/prototypes.yml
+++ b/test/fixtures/prototypes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/prototype_test.rb
+++ b/test/models/prototype_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PrototypeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
一覧表示機能の実装

# Why
一覧を表示させるため

# 実装条件
- プロトタイプ一覧表示ページは、ログイン状況に関係なく、誰でも見ることができること
→◯

- 投稿されているプロトタイプが一覧で表示されること
- プロトタイプ毎に、「画像・プロトタイプ名・キャッチコピー・投稿者の名前」の4つの情報が表示されること
- 画像が表示されており、画像がリンク切れなどになっていないこと。（Renderの仕様による画像のリンク切れは、要件未達に含まれない。Render上では一定時間経過すると画像が消える。）
→× new,createが作成されていないため確認できていません
